### PR TITLE
Fix set checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ This module space is about filling, selecting and clicking on web element.
 - fill\_element(field,value): return 0 if successful, fill the field with the value
 - fill\_elements(fields, data): return 0 if successful, fill each field in the fields dictionary with the value hold in the data dictionary. You can have a larger fields dictionary than the data but each data entry must be found in the fields dictionary. 
 - select\_in\_dropdown(field,visible\_text,value): return 0 if successful, select in the field dropdown the element either described by its visible text or its hidden value. 
-- click\_element(field): return 0 if successful, perform a left click on the field. 
-- set\_checked(field,is\_checked): return 0 if successful, set the check box field so that the is\_checked value is always true i.e. checked if is\_checked set to true and not checked if is\_checked set to false.
+- click\_element(field): return 0 if successful, perform a left click on the field.
+- mouse\_click(field): return 0 if successful, perform a chain action moving the mouse on the element and mouse click element.
+- set\_checked(field,is\_checked): return 0 if successful, set the checkbox field so that the is\_checked value is always true i.e. checked if is\_checked set to true and not checked if is\_checked set to false.
 
 Other documentation
 ===================
@@ -133,6 +134,7 @@ Release Notes
 =============
 - version 1.0.14:
   - fix missing `web_element` variable in `BrowserServer.set_checkbox` method
+  - add `mouse_click` method in the actions
 - version 1.0.13:
   - fix missing `avoid_move_to` passing value to find_from_elements when using find_element in conjunction with `text` parameter. 
 - version 1.0.12:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ To Do
 
 Release Notes
 =============
-
+- version 1.0.14:
+  - fix missing `web_element` variable in `BrowserServer.set_checkbox` method
 - version 1.0.13:
   - fix missing `avoid_move_to` passing value to find_from_elements when using find_element in conjunction with `text` parameter. 
 - version 1.0.12:

--- a/eaiautomatontools/actions.py
+++ b/eaiautomatontools/actions.py
@@ -169,7 +169,8 @@ def select_in_angular_dropdown(driver=None,
 
 
 def click_element(driver=None,
-                  field: dict = None, web_element: WebElement = None) -> int:
+                  field: dict = None,
+                  web_element: WebElement = None) -> int:
     """
     Do simple left click on the given field or on the sub element when web_element is provided
     :param driver: a selenium web driver
@@ -183,17 +184,51 @@ def click_element(driver=None,
     iteration = 0
     while iteration < 5:
         try:
-            web_element = find_element(driver=driver, field=field, web_element=web_element)
-            if web_element is None:
+            found_element = find_element(driver=driver, field=field, web_element=web_element)
+            if found_element is None:
                 iteration += 1
                 continue
-            web_element.click()
+            found_element.click()
             return 0
         except StaleElementReferenceException:
             log.info("StaleElementReferenceException retry after 100ms sleep")
             iteration += 1
             sleep(0.1)
     return 1
+
+
+def mouse_click(driver=None,
+                field: dict = None,
+                web_element: WebElement = None) -> int:
+    """
+    Perform a mouse click in the element center
+    :param driver:
+    :param field:
+    :param web_element:
+    :return:
+    """
+    driver_field_validation(driver, field, log)
+    web_element_validation(web_element, log)
+    iteration = 0
+    found_element = None
+    while iteration < 5:
+        try:
+            found_element = find_element(driver=driver, field=field, web_element=web_element)
+            if found_element is not None:
+                break
+            iteration += 1
+            continue
+        except StaleElementReferenceException:
+            log.info("StaleElementReferenceException retry after 100ms sleep")
+            iteration += 1
+            sleep(0.1)
+    if found_element is None:
+        return 1
+
+    my_action = ActionChains(driver)
+    my_action.click(found_element)
+    my_action.perform()
+    return 0
 
 
 def set_checkbox(driver=None,

--- a/eaiautomatontools/browserServer.py
+++ b/eaiautomatontools/browserServer.py
@@ -25,7 +25,7 @@ from webdriver_manager.utils import ChromeType
 from .navigators import go_to_url, enter_frame, go_to_window
 from .finders import find_element, find_elements, find_from_elements, \
     find_sub_element_from_element
-from .actions import fill_element, fill_elements, select_in_dropdown, set_checkbox, \
+from .actions import fill_element, fill_elements, mouse_click, select_in_dropdown, set_checkbox, \
     click_element, select_in_angular_dropdown, hover_element, select_in_elements
 from .alerts import alert_message, intercept_alert
 from .information import is_alert_present, is_field_exist, is_field_contains_text, \
@@ -352,6 +352,12 @@ class BrowserServer:
         return click_element(driver=self.webdriver,
                              field=field,
                              web_element=web_element)
+
+    def mouse_click(self, field: dict = None, web_element: WebElement = None):
+        """Perform a mouse click on the field. Use the find_element method to find if"""
+        return mouse_click(driver=self.webdriver,
+                           field=field,
+                           web_element=web_element)
 
     def select_in_dropdown(self, field: dict = None, visible_text: str = None, value: str = None):
         """Select in field dropdown either the option by its visible text or its value"""

--- a/eaiautomatontools/browserServer.py
+++ b/eaiautomatontools/browserServer.py
@@ -377,11 +377,14 @@ class BrowserServer:
                                           root_field=root_field,
                                           visible_text=visible_text)
 
-    def set_checkbox(self, field: dict = None, is_checked: bool = None):
+    def set_checkbox(self, field: dict = None,
+                     is_checked: bool = None,
+                     web_element: WebElement = None):
         """Set the field checkbox to the is_checked state"""
         return set_checkbox(driver=self.webdriver,
                             field=field,
-                            is_checked=is_checked)
+                            is_checked=is_checked,
+                            web_element=web_element)
 
     # TODO add unit test
     def hover_element(self, field: dict = None):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiautomatontools",
-    version="1.0.13",
+    version="1.0.14",
     description="UI utilities in order to abstract selenium commands",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/README.md
+++ b/test/README.md
@@ -112,7 +112,8 @@ This module space is about filling, selecting and clicking on web element.
 - fill\_element(field,value): return 0 if successful, fill the field with the value
 - fill\_elements(fields, data): return 0 if successful, fill each field in the fields dictionary with the value hold in the data dictionary. You can have a larger fields dictionary than the data but each data entry must be found in the fields dictionary. 
 - select\_in\_dropdown(field,visible\_text,value): return 0 if successful, select in the field dropdown the element either described by its visible text or its hidden value. 
-- click\_element(field): return 0 if successful, perform a left click on the field. 
+- click\_element(field): return 0 if successful, perform a left click on the field.
+- mouse\_click(field): return 0 if successful, perform a chain action moving the mouse on the element and mouse click element.
 - set\_checked(field,is\_checked): return 0 if successful, set the check box field so that the is\_checked value is always true i.e. checked if is\_checked set to true and not checked if is\_checked set to false.
 
 Other documentation
@@ -133,6 +134,7 @@ Release Notes
 =============
 - version 1.0.14:
   - fix missing `web_element` variable in `BrowserServer.set_checkbox` method
+  - add `mouse_click` method in the actions
 - version 1.0.13:
   - fix missing `avoid_move_to` passing value to find_from_elements when using find_element in conjunction with `text` parameter.
 - version 1.0.12:

--- a/test/README.md
+++ b/test/README.md
@@ -131,6 +131,10 @@ To Do
 
 Release Notes
 =============
+- version 1.0.14:
+  - fix missing `web_element` variable in `BrowserServer.set_checkbox` method
+- version 1.0.13:
+  - fix missing `avoid_move_to` passing value to find_from_elements when using find_element in conjunction with `text` parameter.
 - version 1.0.12:
     - lower log level for finder(s) actions
     - add wait_for_another_window in information

--- a/test/test_04_06_actions_mouse_click_element.md
+++ b/test/test_04_06_actions_mouse_click_element.md
@@ -1,0 +1,105 @@
+# eaiautomatontools.actions.click_element
+
+Present the action utilities for Selenium automaton.
+The click_element method will perform a mouse left click action.
+
+## Background
+
+Launch a test web server serving controlled web pages on localhost port 8081
+
+Use the python resources server.
+
+    >>> from eaiautomatontools.resources.app import Server
+
+    >>> myserver = Server()
+
+    >>> myserver.start()
+    ...
+
+Instantiate a web driver using the eaiautomatontools.browserServer
+
+    >>> from eaiautomatontools.browserServer import BrowserServer
+
+    >>> myWebDriver = BrowserServer()
+
+Use a default browser such as Chrome in 32 bit version
+
+    >>> myWebDriver.browser_name = "chrome"
+
+Serve the web driver
+
+    >>> myWebDriver.serve()
+    0
+  
+  
+
+Open the form test page
+
+    >>> myWebDriver.go_to("http://localhost:8081")
+    0
+
+
+Import the mouse_click tool
+
+    >>> from eaiautomatontools.actions import mouse_click
+
+## Nominal case: give a web driver, give a valid field
+
+You can click a link
+
+    >>> mouse_click(driver=myWebDriver.webdriver,field={'type':'id','value':'tables'})
+    0
+
+    >>> myWebDriver.webdriver.current_url
+    'http://localhost:8081/tables.html'
+
+You can even click a div
+
+    >>> myWebDriver.go_to("http://localhost:8081")
+    0
+
+    >>> mouse_click(driver=myWebDriver.webdriver,field={'type':'id','value':'first'})
+    0
+
+    >>> myWebDriver.webdriver.current_url
+    'http://localhost:8081/'
+
+## Assertions
+
+###  The web driver is missing.
+    >>> mouse_click(field={"type":"id", "value":"name"})
+    Traceback (most recent call last):
+    ...
+    TypeError: Driver is expected
+
+### The field is not valid.
+
+#### Incorrect type key value.
+
+    >>> mouse_click(driver=myWebDriver.webdriver, field={"type":"idl", "value":"name"})
+    Traceback (most recent call last):
+    ...
+    ValueError: The field type is not one the expected: '('id', 'name', 'class_name', 'link_text', 'css', 'partial_link_text', 'xpath', 'tag_name')
+
+#### Incorrect keys value.
+
+    >>> mouse_click(driver=myWebDriver.webdriver, field={"typ":"id", "value":"name"})
+    Traceback (most recent call last):
+    ...
+    KeyError: "The field argument doesn't contains either the 'type' or 'value' key."
+
+## Exceptions
+
+    >>> mouse_click(driver=myWebDriver.webdriver,field={'type':'id','value':'tab'})
+    1
+
+## Teardown
+
+    >>> myWebDriver.close()
+    0
+
+    >>> myWebDriver = None
+
+    >>> myserver.stop()
+
+    >>> myserver = None


### PR DESCRIPTION
# Update

- Add `mouse_click` method ( `mouse_click( driver: WebDriver, field: dict, web_element: WebElement= None)`) from `actions` module.
- `mouse_click` in `BrowserServer`

# Fix

- missing `web_element` variable in `set_checkbox` method (`BrowserServer`)